### PR TITLE
Read the README from the appropriate extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup, find_packages
 
-with open('README.rst') as readme_file:
+with open('README.md') as readme_file:
     readme = readme_file.read()
 
 with open('HISTORY.rst') as history_file:


### PR DESCRIPTION
The README is currently written in markdown but was being read as `.rst`
causing an installation error when using setup.py/pip.